### PR TITLE
reuse global rand in sampling functions

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -196,12 +196,17 @@ func checkSampleRate(r float32) error {
 	return nil
 }
 
+var fireRand *rand.Rand
+
+func init() {
+	// use rand.Seed to reset fireRand regularly?
+	fireRand = rand.New(rand.NewSource(time.Now().UnixNano()))
+}
+
 func shouldFire(sampleRate float32) bool {
 	if sampleRate == 1 {
 		return true
 	}
 
-	r := rand.New(rand.NewSource(time.Now().UnixNano()))
-
-	return r.Float32() <= sampleRate
+	return fireRand.Float32() <= sampleRate
 }

--- a/conn_test.go
+++ b/conn_test.go
@@ -1,0 +1,74 @@
+package statsd
+
+import "testing"
+
+func Test_shouldFire(t *testing.T) {
+	type args struct {
+		sampleRate float32
+	}
+	tests := []struct {
+		name     string
+		args     args
+		errAllow float32
+	}{
+		{
+			name: "sample-0.1",
+			args: args{
+				sampleRate: 0.1,
+			},
+			errAllow: 0.005,
+		},
+		{
+			name: "sample-0.5",
+			args: args{
+				sampleRate: 0.5,
+			},
+			errAllow: 0.005,
+		},
+		{
+			name: "sample-0.8",
+			args: args{
+				sampleRate: 0.8,
+			},
+			errAllow: 0.005,
+		},
+		{
+			name: "sample-0.01",
+			args: args{
+				sampleRate: 0.01,
+			},
+			errAllow: 0.005,
+		},
+		{
+			name: "sample-0.05",
+			args: args{
+				sampleRate: 0.05,
+			},
+			errAllow: 0.005,
+		},
+		{
+			name: "sample-0.08",
+			args: args{
+				sampleRate: 0.08,
+			},
+			errAllow: 0.005,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var total, fireCnt float32
+			for i := 0; i < 0xffffff; i++ {
+				if shouldFire(tt.args.sampleRate) {
+					fireCnt++
+				}
+				total++
+			}
+
+			if ret := fireCnt / total; ret-tt.args.sampleRate > tt.errAllow {
+				t.Fatalf("[%s] ret: %.4f <=> want: %.4f",
+					tt.name, ret, tt.args.sampleRate)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Hi, I found a huge performance problem if the sample is not equal to 0 in `shouldFire` function.

```go
func shouldFire(sampleRate float32) bool {
	if sampleRate == 1 {
		return true
	}

	r := rand.New(rand.NewSource(time.Now().UnixNano())) // <<<<= making system call every time

	return r.Float32() <= sampleRate
}
```

Because it will renew a `rand.Rand` every time it cost a lot. So I use a global `rand.Rand` variables and set seed in init function.

Please review this PR.